### PR TITLE
ci: add Pulumi summary as PR comment

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -141,6 +141,7 @@ jobs:
           command: up
           refresh: true
           comment-on-summary: true
+          suppress-progress: true
 
       - name: Cancel update on failure
         if: failure() || cancelled()


### PR DESCRIPTION
For some reason they stopped working, this PR tries to fix it.

Extra:
- Suppress useless progress lines for cleaner log output
- Add Pulumi summary on CI step